### PR TITLE
Cleaner Syntax

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -42,15 +42,11 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const mapDispatchToProps = dispatch => {
-  return {
-    updatePostsData: data => dispatch(updatePostsData(data)),
-    setNavigatorIsAside: val => dispatch(setNavigatorIsAside(val)),
-    setNavigatorInTransition: val => dispatch(setNavigatorInTransition(val))
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(BlogIndex);
+export default connect(mapStateToProps, {
+	updatePostsData,
+	setNavigatorIsAside,
+	setNavigatorInTransition
+})(BlogIndex);
 
 export const pageQuery = graphql`
   query IndexQuery {


### PR DESCRIPTION
I don't know if you knew this little trick, or just preferred to do the whole mapDispatchToProps. But you can do it in a cleaner syntax this way. Please feel free to reject the PR if you did this consciously.